### PR TITLE
Automatic update of xunit to 2.3.1

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -13,9 +13,7 @@
     <ProjectReference Include="..\TestSubjects\TestSubjects.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit">
-      <Version>2.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">


### PR DESCRIPTION
NuKeeper has generated an update of `xunit` to `2.3.1` from `2.3.0`
`xunit 2.3.1` was published at `2017-10-27T05:56:35Z`, 5 months ago

1 project update:
Updated `Tests\Tests.csproj` to `xunit` `2.3.1` from `2.3.0`

This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
