### PR TITLE
Automatic update of xunit.runner.visualstudio to 2.3.1

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
NuKeeper has generated an update of `xunit.runner.visualstudio` to `2.3.1` from `2.3.0`
`xunit.runner.visualstudio 2.3.1` was published at `2017-10-27T05:59:05Z`, 5 months ago

1 project update:
Updated `Tests\Tests.csproj` to `xunit.runner.visualstudio` `2.3.1` from `2.3.0`

This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
