### PR TITLE
Added support for ByRef parameters which were unsupported

### DIFF
--- a/ExposedObject/ExposedObject.csproj
+++ b/ExposedObject/ExposedObject.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/skolima/ExposedObject</PackageProjectUrl>
     <Description>Fast dynamic wrapper for accessing hidden methods and fields of .Net objects.</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />

--- a/ExposedObject/MetaObject.cs
+++ b/ExposedObject/MetaObject.cs
@@ -87,6 +87,9 @@ namespace ExposedObject
             {
                 argTypes[i] = args[i].LimitType;
                 argExps[i] = args[i].Expression;
+
+                if (args[i].Expression is ParameterExpression pe && pe.IsByRef)
+                    argTypes[i] = argTypes[i].MakeByRefType();
             }
 
             var type = exposed.SubjectType;

--- a/ExposedObject/MetaObject.cs
+++ b/ExposedObject/MetaObject.cs
@@ -1,6 +1,6 @@
 ﻿// Author:
 // Leszek Ciesielski (skolima@gmail.com)
-// Manuel Josupeit-Walter (josupeit-walter@cis-gmbh.de)
+// Manuel Josupeit-Walter (info@josupeit.com)
 //
 // (C) 2013 Cognifide
 //

--- a/TestSubjects/ClassWithByRefParameters.cs
+++ b/TestSubjects/ClassWithByRefParameters.cs
@@ -1,0 +1,48 @@
+﻿// Author:
+// Manuel Josupeit-Walter (info@josupeit.com)
+//
+// (C) 2013 Cognifide
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Globalization;
+
+#pragma warning disable CA1822 // because we want to test instance methods
+
+namespace TestSubjects
+{
+    public class ClassWithByRefParameters
+    {
+        public int PublicMethod(int param1, out string param2, in long param3, ref byte param4)
+        {
+            param2 = param3.ToString(CultureInfo.InvariantCulture);
+            param4 = unchecked((byte)param1);
+            return 0;
+        }
+
+        protected int ProtectedMethod(int param1, out string param2, in long param3, ref byte param4)
+        {
+            param2 = param3.ToString(CultureInfo.InvariantCulture);
+            param4 = unchecked((byte)param1);
+            return 0;
+        }
+    }
+}

--- a/TestSubjects/ClassWithHiddenMethods.cs
+++ b/TestSubjects/ClassWithHiddenMethods.cs
@@ -1,6 +1,6 @@
 ﻿// Author:
 // Leszek Ciesielski (skolima@gmail.com)
-// Manuel Josupeit-Walter (josupeit-walter@cis-gmbh.de)
+// Manuel Josupeit-Walter (info@josupeit.com)
 //
 // (C) 2013 Cognifide
 //

--- a/TestSubjects/ClassWithInheritedPrivateMembers.cs
+++ b/TestSubjects/ClassWithInheritedPrivateMembers.cs
@@ -1,6 +1,6 @@
 ﻿// Author:
 // Leszek Ciesielski (skolima@gmail.com)
-// Manuel Josupeit-Walter (josupeit-walter@cis-gmbh.de)
+// Manuel Josupeit-Walter (info@josupeit.com)
 //
 // (C) 2013 Cognifide
 //

--- a/Tests/ClassWithByRefParametersTest.cs
+++ b/Tests/ClassWithByRefParametersTest.cs
@@ -1,0 +1,68 @@
+﻿// Author:
+// Manuel Josupeit-Walter (info@josupeit.com)
+//
+// (C) 2011 Cognifide
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using ExposedObject;
+using TestSubjects;
+using Xunit;
+
+namespace Tests
+{
+    public class ClassWithByRefParametersTest
+    {
+        [Fact]
+        public void PublicMethodTest()
+        {
+            var exposed = Exposed.From(new ClassWithByRefParameters());
+
+            var param1 = 123;
+            string param2 = null;
+            var param3 = 2937842L;
+            byte param4 = 111;
+
+            int result = exposed.PublicMethod(param1, ref param2, ref param3, ref param4);
+
+            Assert.Equal(0, result);
+            Assert.Equal("2937842", param2);
+            Assert.Equal(123, param4);
+        }
+
+        [Fact]
+        public void ProtectedMethodTest()
+        {
+            var exposed = Exposed.From(new ClassWithByRefParameters());
+
+            var param1 = 123;
+            string param2 = null;
+            var param3 = 2937842L;
+            byte param4 = 111;
+
+            int result = exposed.ProtectedMethod(param1, ref param2, ref param3, ref param4);
+
+            Assert.Equal(0, result);
+            Assert.Equal("2937842", param2);
+            Assert.Equal(123, param4);
+        }
+    }
+}

--- a/Tests/ClassWithInheritedPrivateMembersTest.cs
+++ b/Tests/ClassWithInheritedPrivateMembersTest.cs
@@ -1,6 +1,6 @@
 ﻿// Author:
 // Leszek Ciesielski (skolima@gmail.com)
-// Manuel Josupeit-Walter (josupeit-walter@cis-gmbh.de)
+// Manuel Josupeit-Walter (info@josupeit.com)
 //
 // (C) 2013 Cognifide
 //

--- a/Tests/HiddenClassTest.cs
+++ b/Tests/HiddenClassTest.cs
@@ -1,6 +1,6 @@
 ﻿// Author:
 // Leszek Ciesielski (skolima@gmail.com)
-// Manuel Josupeit-Walter (josupeit-walter@cis-gmbh.de)
+// Manuel Josupeit-Walter (info@josupeit.com)
 //
 // (C) 2013 Cognifide
 //


### PR DESCRIPTION
The library was unable to find the correct method if its signature contained ByRef parameters, like ``ref``, ``out`` or ``in``. This pull-request addresses the issue.