### PR TITLE
bugfix: Work around DLR call site caching when derived types are run through the same method

### DIFF
--- a/ExposedObject/MetaObject.cs
+++ b/ExposedObject/MetaObject.cs
@@ -108,7 +108,7 @@ namespace ExposedObject
 
             var @this = isStatic
                             ? null
-                            : Expression.Convert(Expression.Field(Expression.Convert(self, typeof(Exposed)), "value"), type);
+                            : Expression.Convert(Expression.Field(Expression.Convert(self, typeof(Exposed)), "value"), method.ReflectedType ?? type);
 
             var target = Expression.Call(@this, method, argExps);
             var restrictions = BindingRestrictions.GetTypeRestriction(self, typeof(Exposed));
@@ -182,9 +182,6 @@ namespace ExposedObject
         {
             MemberExpression? memberExpression = null;
             var type = ((Exposed)Value!).SubjectType;
-            var @this = isStatic
-                            ? null
-                            : Expression.Convert(Expression.Field(Expression.Convert(self, typeof(Exposed)), "value"), type);
             var declaringType = type;
 
             do
@@ -192,14 +189,14 @@ namespace ExposedObject
                 var property = declaringType.GetProperty(memberName, GetBindingFlags());
                 if (property != null)
                 {
-                    memberExpression = Expression.Property(@this, property);
+                    memberExpression = Expression.Property(ConvertedExpression(property.ReflectedType ?? type), property);
                 }
                 else
                 {
                     var field = declaringType.GetField(memberName, GetBindingFlags());
                     if (field != null)
                     {
-                        memberExpression = Expression.Field(@this, field);
+                        memberExpression = Expression.Field(ConvertedExpression(field.ReflectedType ?? type), field);
                     }
                 }
             }
@@ -211,6 +208,10 @@ namespace ExposedObject
             }
 
             return memberExpression;
+
+            Expression? ConvertedExpression(Type memberType) => isStatic
+                                                    ? null
+                                                    : Expression.Convert(Expression.Field(Expression.Convert(self, typeof(Exposed)), "value"), memberType);
         }
 
         /// <summary>
@@ -247,7 +248,7 @@ namespace ExposedObject
         {
             return isStatic
                        ? BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic
-                       : BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                       : BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
         }
     }
 }

--- a/TestSubjects/CallSiteCachingClasses.cs
+++ b/TestSubjects/CallSiteCachingClasses.cs
@@ -1,0 +1,53 @@
+﻿namespace TestSubjects
+{
+    public class BaseClass
+    {
+        #pragma warning disable CA1051 // Do not declare visible instance fields
+        protected string _field = nameof(BaseClass);
+        #pragma warning restore CA1051 // Do not declare visible instance fields
+
+        protected string Property
+        {
+            get
+            {
+                return _field;
+            }
+            set
+            {
+                _field = value;
+            }
+        }
+        protected string Method() => _field;
+
+
+        public virtual string OverriddenMethod() => nameof(BaseClass);
+        public virtual string OverriddenProperty => nameof(BaseClass);
+
+        public string HiddenMethod() => nameof(BaseClass);
+
+        public string HiddenProperty => nameof(BaseClass);
+
+#pragma warning disable CA1051 // Do not declare visible instance fields
+        protected string _hiddenField = nameof(BaseClass);
+#pragma warning restore CA1051 // Do not declare visible instance fields
+    }
+
+    public class ChildClass : BaseClass
+    {
+        public ChildClass()
+        {
+            _field = nameof(ChildClass);
+        }
+
+        public override string OverriddenMethod() => nameof(ChildClass);
+        public override string OverriddenProperty => nameof(ChildClass);
+
+        public new string HiddenMethod() => nameof(ChildClass);
+
+        public new string HiddenProperty => nameof(ChildClass);
+
+#pragma warning disable CA1051 // Do not declare visible instance fields
+        protected new string _hiddenField = nameof(ChildClass);
+#pragma warning restore CA1051 // Do not declare visible instance fields
+    }
+}

--- a/Tests/CallSiteCachingTest.cs
+++ b/Tests/CallSiteCachingTest.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExposedObject;
+using TestSubjects;
+using Xunit;
+
+namespace Tests
+{
+    public class CallSiteCachingTest
+    {
+        [Fact]
+        public void OverriddenMethodTest()
+        {
+            dynamic child = Exposed.From(new ChildClass());
+            Assert.Equal(nameof(ChildClass), child.OverriddenMethod());
+        }
+
+        [Fact]
+        public void OverriddenPropertyTest()
+        {
+            dynamic child = Exposed.From(new ChildClass());
+            Assert.Equal(nameof(ChildClass), child.OverriddenProperty);
+        }
+
+        [Fact]
+        public void HiddenMethodTest()
+        {
+            dynamic child = Exposed.From(new ChildClass());
+            Assert.Equal(nameof(ChildClass), child.HiddenMethod());
+        }
+
+        [Fact]
+        public void HiddenPropertyTest()
+        {
+            dynamic child = Exposed.From(new ChildClass());
+            Assert.Equal(nameof(ChildClass), child.HiddenProperty);
+        }
+
+        [Fact]
+        public void HiddenFieldTest()
+        {
+            dynamic child = Exposed.From(new ChildClass());
+            Assert.Equal(nameof(ChildClass), child._hiddenField);
+        }
+
+        [Fact]
+        public void CallSiteTypeCachingInheritedMethodTest()
+        {
+            CallHiddenMethod(new ChildClass());
+            CallHiddenMethod(new BaseClass());
+
+            static string CallHiddenMethod(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed.Method();
+            }
+        }
+
+        [Fact]
+        public void CallSiteTypeCachingInheritedPropertyTest()
+        {
+            var childValue = GetHiddenPropertyValue(new ChildClass());
+            var parentValue = GetHiddenPropertyValue(new BaseClass());
+
+            Assert.Equal(nameof(ChildClass), childValue);
+            Assert.Equal(nameof(BaseClass), parentValue);
+
+            static string GetHiddenPropertyValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed.Property;
+            }
+        }
+
+        [Fact]
+        public void CallSiteTypeCachingInheritedFieldTest()
+        {
+            var childValue = GetHiddenFieldValue(new ChildClass());
+            var parentValue = GetHiddenFieldValue(new BaseClass());
+
+            Assert.Equal(nameof(ChildClass), childValue);
+            Assert.Equal(nameof(BaseClass), parentValue);
+
+            static string GetHiddenFieldValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed._field;
+            }
+        }
+
+        // FIXME: The below show advanced situations where the call site type caching isn't as easily worked around
+        [Fact(Skip = "Not yet working")]
+        public void CallSiteTypeCachingHiddenMethodTest()
+        {
+            Assert.Equal(nameof(ChildClass), GetHiddenMethodValue(new ChildClass()));
+            Assert.Equal(nameof(BaseClass), GetHiddenMethodValue(new BaseClass()));
+
+            static string GetHiddenMethodValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed.HiddenMethod();
+            }
+        }
+
+        [Fact(Skip = "Not yet working")]
+        public void CallSiteTypeCachingHiddenPropertyTest()
+        {
+            Assert.Equal(nameof(ChildClass), GetHiddenPropertyValue(new ChildClass()));
+            Assert.Equal(nameof(BaseClass), GetHiddenPropertyValue(new BaseClass()));
+
+            static string GetHiddenPropertyValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed.HiddenProperty;
+            }
+        }
+
+        [Fact(Skip = "Not yet working")]
+        public void CallSiteTypeCachingHiddenFieldTest()
+        {
+            Assert.Equal(nameof(ChildClass), GetHiddenFieldValue(new ChildClass()));
+
+            // If this test fails, will throw an InvalidCastException
+            Assert.Equal(nameof(BaseClass), GetHiddenFieldValue(new BaseClass()));
+
+            static string GetHiddenFieldValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed._hiddenField;
+            }
+        }
+
+        [Fact(Skip = "Not yet working")]
+        public void CallSiteTypeCachingOverriddenMethodTest()
+        {
+            Assert.Equal(nameof(ChildClass), GetOverriddenMethodValue(new ChildClass()));
+
+            // If this test fails, will throw an InvalidCastException
+            Assert.Equal(nameof(BaseClass), GetOverriddenMethodValue(new BaseClass()));
+
+            static string GetOverriddenMethodValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed.OverriddenMethod();
+            }
+        }
+
+        [Fact(Skip = "Not yet working")]
+        public void CallSiteTypeCachingOverriddenPropertyTest()
+        {
+            Assert.Equal(nameof(ChildClass), GetOverriddenPropertyValue(new ChildClass()));
+
+            // If this test fails, will throw an InvalidCastException
+            Assert.Equal(nameof(BaseClass), GetOverriddenPropertyValue(new BaseClass()));
+
+            static string GetOverriddenPropertyValue(Object o)
+            {
+                dynamic exposed = Exposed.From(o);
+                return exposed.OverriddenProperty;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Been tracking this Heisenbug for a year.  My software's latest release pushed the proportion of users running into it from 2% to 30%, which gave me enough data points to figure out what was happening.

More detail in the commit message:
> The Dynamic Language Runtime caches a dynamic's Type at a particular call site.  This can trigger an InvalidTypeException in methods that process more than one type in the same line of code, even those types are compatible via inheritance.  This change works around the problem by supplying the type that declares the method or member being accessed to the DLR cache instead of the instance type that was originally Exposed.  This doesn't solve cases where the method or member is overridden or hidden by one of the types, but it also doesn't break them further.